### PR TITLE
"externals" defined twice, overwriting the top one

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -45,9 +45,6 @@ const config = {
       context: path.resolve(__dirname, 'node_modules')
     })
   ],
-  externals: [
-    /\/lib\/(enonic|xp)\/.+/
-  ],
   mode: env.type,
   // Source maps are not usable in server scripts
   devtool: false,


### PR DESCRIPTION
You have double definitions for externals in your server webpack config. This makes the last definition win, and it was rather hard for us to spot why nothing was built correctly.  Removing the last definition fixes the build.