### PR TITLE
Output from TypeScript compilation depends on ts-files #37

### DIFF
--- a/src/main/resources/tsconfig.server.json
+++ b/src/main/resources/tsconfig.server.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
+    "sourceMap": false,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "assets"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,5 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "strictNullChecks": true
-  },
-  "types": [
-    "types"
-  ]
+  }
 }

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -19,7 +19,7 @@ const config = {
   context: path.join(__dirname, RESOURCES_PATH),
   entry: {},
   externals: [
-    /(\/lib\/(enonic|xp|mustache|thymeleaf))?\/.+/
+    /^\/lib\/(.+|\$)$/i
   ],
   output: {
     path: path.join(__dirname, '/build/resources/main'),
@@ -31,7 +31,16 @@ const config = {
   },
   optimization: {
     minimizer: [
-      new TerserPlugin(),
+      new TerserPlugin({
+        sourceMap: false,
+        terserOptions: {
+          compress: {
+            drop_console: false,
+          },
+          keep_classnames: true,
+          keep_fnames: true,
+        }
+      }),
     ],
     splitChunks: {
       minSize: 30000,
@@ -40,7 +49,7 @@ const config = {
   mode: env.type,
   // Source maps are not usable in server scripts
   devtool: false,
-}
+};
 
 // ----------------------------------------------------------------------------
 // JavaScript loaders


### PR DESCRIPTION
Fixed the TS optimization by preventing removal of the console statements, which leads to an empty JS output file.
Removed invalid "types" field from the basic TS config.