### PR TITLE
Add polyfill for Object.assign

### DIFF
--- a/src/main/resources/polyfills.js
+++ b/src/main/resources/polyfills.js
@@ -1,0 +1,23 @@
+exports.assign = function (target, firstSource) {
+  if (target === undefined || target === null) {
+    throw new TypeError('Cannot convert first argument to object');
+  }
+
+  var to = Object(target);
+  for (var i = 1; i < arguments.length; i++) {
+    var nextSource = arguments[i];
+    if (nextSource === undefined || nextSource === null) {
+      continue;
+    }
+
+    var keysArray = Object.keys(Object(nextSource));
+    for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+      var nextKey = keysArray[nextIndex];
+      var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+      if (desc !== undefined && desc.enumerable) {
+        to[nextKey] = nextSource[nextKey];
+      }
+    }
+  }
+  return to;
+};

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const glob = require('glob');
 const R = require('ramda');
+const {ProvidePlugin} = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const {
   setEntriesForPath,
   addRule,
+  addPlugin,
   prependExtensions
 } = require('./util/compose');
 const env = require('./util/env');
@@ -85,6 +87,9 @@ function addTypeScriptSupport(cfg) {
   return R.pipe(
     setEntriesForPath(entries),
     addRule(rule),
+    addPlugin(new ProvidePlugin({
+      'Object.assign': [path.join(__dirname, RESOURCES_PATH, 'polyfills'), 'assign']
+    })),
     prependExtensions(['.ts', '.json'])
   )(cfg);
 }


### PR DESCRIPTION
This commit polyfills `Object.assign` serverside for both TypeScript-
and Babel-based builds.

Part of the goal here is to show developers how to polyfill methods
that are used by imported libraries, but that are not supported by
Nashorn.

This is why we chose to add new file in resources named
`polyfills.js`, instead of using a npm-library. Resolving the
function should be obvious by looking at the naming of the files,
the export, and the usage in `webpack.server.config.js`.

The polyfill for `Object.assign` has been copied from *starter-esbuild*.
https://github.com/enonic/starter-esbuild/blob/master/src/main/resources/lib/nashorn/assign.js

Closes: #49